### PR TITLE
Use Zotero metadata for matched external works

### DIFF
--- a/src/services/externalWorkMetadataService.ts
+++ b/src/services/externalWorkMetadataService.ts
@@ -1,6 +1,7 @@
 import type {
   CitationProviderID,
   RelatedWorkMetadata,
+  RelatedWorkPropertyName,
 } from "../domain/citationTypes";
 import type { ExternalWork } from "../domain/externalWork";
 import { mergeRelatedWorkMetadata } from "../domain/relatedWorkMetadata";
@@ -18,14 +19,27 @@ import {
 } from "./scholarlyTextService";
 
 export interface LocalExternalWorkIndexes {
-  byDOI: Map<string, string>;
-  byTitle: Map<string, string>;
+  byKey: Map<string, LibraryWorkIdentity>;
+  byDOI: Map<string, LibraryWorkIdentity>;
+  byTitle: Map<string, LibraryWorkIdentity>;
 }
 
+/**
+ * Local bibliographic metadata available while external relationship records
+ * are projected into the UI. The additional fields are optional so existing
+ * identity-only callers remain valid, while graph nodes and ZoteroPaper values
+ * can supply richer local fallbacks without another Zotero lookup.
+ */
 export interface LibraryWorkIdentity {
   itemKey: string;
   doi: string | null;
   title: string;
+  authors?: readonly string[];
+  year?: number | null;
+  publicationDate?: string | null;
+  sourceTitle?: string | null;
+  abstract?: string | null;
+  libraryID?: number | null;
 }
 
 export function usableExternalTitle(
@@ -132,21 +146,114 @@ export function mergeExternalWorkMetadata<T extends RelatedWorkMetadata>(
 export function localExternalWorkIndexes(
   nodes: readonly LibraryWorkIdentity[],
 ): LocalExternalWorkIndexes {
-  const byDOI = new Map<string, string>();
-  const byTitle = new Map<string, string>();
+  const byKey = new Map<string, LibraryWorkIdentity>();
+  const byDOI = new Map<string, LibraryWorkIdentity>();
+  const byTitle = new Map<string, LibraryWorkIdentity>();
   for (const node of nodes) {
+    const key = String(node.itemKey ?? "").trim().toLocaleUpperCase();
     const doi = normalizeDOI(node.doi);
     const title = normalizeExactTitle(node.title);
-    if (doi && !byDOI.has(doi)) byDOI.set(doi, node.itemKey);
-    if (title && !byTitle.has(title)) byTitle.set(title, node.itemKey);
+    if (key && !byKey.has(key)) byKey.set(key, node);
+    if (doi && !byDOI.has(doi)) byDOI.set(doi, node);
+    if (title && !byTitle.has(title)) byTitle.set(title, node);
   }
-  return { byDOI, byTitle };
+  return { byKey, byDOI, byTitle };
+}
+
+function localWorkForExternal(
+  work: RelatedWorkMetadata,
+  localByDOI: Map<string, LibraryWorkIdentity>,
+  localByTitle: Map<string, LibraryWorkIdentity>,
+  localByKey?: Map<string, LibraryWorkIdentity>,
+): LibraryWorkIdentity | null {
+  const explicitKey = String(
+    work.inLibraryItemKey ?? work.zoteroItemKey ?? "",
+  )
+    .trim()
+    .toLocaleUpperCase();
+  if (explicitKey && localByKey) {
+    const explicit = localByKey.get(explicitKey);
+    if (explicit) return explicit;
+  }
+
+  const doi = normalizeDOI(work.doi);
+  if (doi) {
+    const doiMatch = localByDOI.get(doi);
+    if (doiMatch) return doiMatch;
+  }
+
+  const title = normalizeExactTitle(work.title);
+  if (!title) return null;
+  const titleMatch = localByTitle.get(title) ?? null;
+  if (!titleMatch) return null;
+
+  // A title fallback may bridge a record whose DOI is missing locally, but it
+  // must never join two records that already have conflicting DOI identities.
+  const localDOI = normalizeDOI(titleMatch.doi);
+  if (doi && localDOI && doi !== localDOI) return null;
+  return titleMatch;
+}
+
+function nonEmptyText(value: string | null | undefined): string | null {
+  const normalized = normalizeScholarlyText(value);
+  return normalized || null;
+}
+
+function mergeLocalZoteroMetadata<T extends RelatedWorkMetadata>(
+  work: T,
+  local: LibraryWorkIdentity,
+): T {
+  const workDOI = normalizeDOI(work.doi);
+  const localDOI = normalizeDOI(local.doi);
+  const workTitle = usableExternalTitle(work.title, workDOI);
+  const localTitle = usableExternalTitle(local.title, localDOI);
+  const workAuthors = work.authors.map((author) => author.trim()).filter(Boolean);
+  const localAuthors = (local.authors ?? [])
+    .map((author) => String(author ?? "").trim())
+    .filter(Boolean);
+  const workPublicationDate = String(work.publicationDate ?? "").trim();
+  const localPublicationDate = String(local.publicationDate ?? "").trim();
+  const workSourceTitle = nonEmptyText(work.sourceTitle);
+  const localSourceTitle = nonEmptyText(local.sourceTitle);
+  const workAbstract = nonEmptyText(work.abstract);
+  const localAbstract = nonEmptyText(local.abstract);
+
+  const localFields: RelatedWorkPropertyName[] = [];
+  if (!workDOI && localDOI) localFields.push("doi");
+  if (!workTitle && localTitle) localFields.push("title");
+  if (!workAuthors.length && localAuthors.length) localFields.push("authors");
+  if (work.year == null && local.year != null) localFields.push("year");
+  if (!workPublicationDate && localPublicationDate) {
+    localFields.push("publicationDate");
+  }
+  if (!workSourceTitle && localSourceTitle) localFields.push("sourceTitle");
+  if (!workAbstract && localAbstract) localFields.push("abstract");
+
+  const propertySources = { ...(work.propertySources ?? {}) };
+  for (const property of localFields) propertySources[property] = ["zotero"];
+
+  return normalizeRelatedWorkText({
+    ...work,
+    doi: workDOI ?? localDOI,
+    title: workTitle ?? localTitle ?? work.title,
+    authors: workAuthors.length ? workAuthors : localAuthors,
+    year: work.year ?? local.year ?? null,
+    publicationDate:
+      workPublicationDate || localPublicationDate || work.publicationDate || null,
+    sourceTitle: workSourceTitle ?? localSourceTitle,
+    abstract: workAbstract ?? localAbstract,
+    zoteroItemKey: work.zoteroItemKey ?? local.itemKey,
+    inLibraryItemKey: local.itemKey,
+    zoteroLibraryID: work.zoteroLibraryID ?? local.libraryID ?? null,
+    propertySources,
+  } as T);
 }
 
 export function toExternalWork(
   work: RelatedWorkMetadata,
-  localByDOI: Map<string, string>,
-  localByTitle: Map<string, string>,
+  localByDOI: Map<string, LibraryWorkIdentity>,
+  localByTitle: Map<string, LibraryWorkIdentity>,
+  localByKey?: Map<string, LibraryWorkIdentity>,
 ): ExternalWork {
   const key = stableExternalWorkIdentity(work);
   const resolved = normalizeRelatedWorkText(
@@ -154,14 +261,19 @@ export function toExternalWork(
       ? mergeExternalWorkMetadata(work, cachedExternalWorkMetadata(key))
       : work,
   );
-  const doi = normalizeDOI(resolved.doi);
-  const title = normalizeExactTitle(resolved.title);
+  const local = localWorkForExternal(
+    resolved,
+    localByDOI,
+    localByTitle,
+    localByKey,
+  );
+  const enriched = local ? mergeLocalZoteroMetadata(resolved, local) : resolved;
   const external: ExternalWork = {
-    ...resolved,
+    ...enriched,
     inLibraryItemKey:
-      (doi ? localByDOI.get(doi) : null) ??
-      (title ? localByTitle.get(title) : null) ??
-      resolved.zoteroItemKey ??
+      local?.itemKey ??
+      enriched.inLibraryItemKey ??
+      enriched.zoteroItemKey ??
       null,
   };
   registerExternalWorkMetrics(external);
@@ -174,6 +286,6 @@ export function toExternalWorks(
 ): ExternalWork[] {
   const indexes = localExternalWorkIndexes(libraryNodes);
   return works.map((work) =>
-    toExternalWork(work, indexes.byDOI, indexes.byTitle),
+    toExternalWork(work, indexes.byDOI, indexes.byTitle, indexes.byKey),
   );
 }

--- a/test/externalWorkMetadataService.test.ts
+++ b/test/externalWorkMetadataService.test.ts
@@ -1,0 +1,132 @@
+import { expect } from "chai";
+import type { RelatedWorkMetadata } from "../src/domain/citationTypes";
+import { externalWorkToFocusNode } from "../src/services/graphFocusService";
+import {
+  toExternalWork,
+  toExternalWorks,
+  localExternalWorkIndexes,
+  type LibraryWorkIdentity,
+} from "../src/services/externalWorkMetadataService";
+
+function externalWork(
+  overrides: Partial<RelatedWorkMetadata> = {},
+): RelatedWorkMetadata {
+  return {
+    provider: "openalex",
+    providerWorkID: "W123",
+    doi: "10.1000/example",
+    title: null,
+    year: null,
+    publicationDate: null,
+    authors: [],
+    sourceTitle: null,
+    abstract: null,
+    ...overrides,
+  };
+}
+
+function localWork(
+  overrides: Partial<LibraryWorkIdentity> = {},
+): LibraryWorkIdentity {
+  return {
+    itemKey: "LOCAL1",
+    doi: "10.1000/example",
+    title: "Local Zotero title",
+    authors: ["Local Author"],
+    year: 2021,
+    publicationDate: "2021-06-01",
+    sourceTitle: "Local Journal",
+    abstract: "Local abstract",
+    libraryID: 1,
+    ...overrides,
+  };
+}
+
+describe("External work local Zotero enrichment", function () {
+  it("fills missing bibliographic fields from a DOI-matched Zotero item", function () {
+    const [resolved] = toExternalWorks([externalWork()], [localWork()]);
+
+    expect(resolved.inLibraryItemKey).to.equal("LOCAL1");
+    expect(resolved.zoteroItemKey).to.equal("LOCAL1");
+    expect(resolved.zoteroLibraryID).to.equal(1);
+    expect(resolved.title).to.equal("Local Zotero title");
+    expect(resolved.authors).to.deep.equal(["Local Author"]);
+    expect(resolved.year).to.equal(2021);
+    expect(resolved.publicationDate).to.equal("2021-06-01");
+    expect(resolved.sourceTitle).to.equal("Local Journal");
+    expect(resolved.abstract).to.equal("Local abstract");
+    expect(resolved.propertySources?.title).to.deep.equal(["zotero"]);
+    expect(resolved.propertySources?.authors).to.deep.equal(["zotero"]);
+  });
+
+  it("retains valid provider metadata while filling only missing fields", function () {
+    const [resolved] = toExternalWorks(
+      [
+        externalWork({
+          title: "Provider title",
+          authors: ["Provider Author"],
+          year: 2020,
+          sourceTitle: "Provider Journal",
+        }),
+      ],
+      [localWork()],
+    );
+
+    expect(resolved.title).to.equal("Provider title");
+    expect(resolved.authors).to.deep.equal(["Provider Author"]);
+    expect(resolved.year).to.equal(2020);
+    expect(resolved.sourceTitle).to.equal("Provider Journal");
+    expect(resolved.publicationDate).to.equal("2021-06-01");
+    expect(resolved.abstract).to.equal("Local abstract");
+  });
+
+  it("uses an explicit Zotero item key before DOI or title lookup", function () {
+    const works = [
+      localWork({ itemKey: "LOCAL1", doi: "10.1000/one", title: "One" }),
+      localWork({ itemKey: "LOCAL2", doi: "10.1000/two", title: "Two" }),
+    ];
+    const indexes = localExternalWorkIndexes(works);
+    const resolved = toExternalWork(
+      externalWork({
+        doi: null,
+        title: null,
+        inLibraryItemKey: "LOCAL2",
+      }),
+      indexes.byDOI,
+      indexes.byTitle,
+      indexes.byKey,
+    );
+
+    expect(resolved.inLibraryItemKey).to.equal("LOCAL2");
+    expect(resolved.title).to.equal("Two");
+  });
+
+  it("does not title-match records whose known DOIs conflict", function () {
+    const [resolved] = toExternalWorks(
+      [
+        externalWork({
+          doi: "10.1000/external",
+          title: "Same normalized title",
+        }),
+      ],
+      [
+        localWork({
+          itemKey: "LOCAL-CONFLICT",
+          doi: "10.1000/local",
+          title: "Same normalized title",
+        }),
+      ],
+    );
+
+    expect(resolved.inLibraryItemKey).to.equal(null);
+    expect(resolved.title).to.equal("Same normalized title");
+  });
+
+  it("gives Focus View the locally recovered title and authors", function () {
+    const [resolved] = toExternalWorks([externalWork()], [localWork()]);
+    const node = externalWorkToFocusNode(resolved, "reference");
+
+    expect(node.title).to.equal("Local Zotero title");
+    expect(node.authors).to.deep.equal(["Local Author"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fix external relationship records that are already matched to a Zotero item but still render as `Title unavailable` / `Authors unavailable`.

### Changes

- Extend `LibraryWorkIdentity` with optional local bibliographic fields.
- Index local works by item key, DOI, and normalized title.
- Prefer explicit Zotero item-key matches, then DOI, then title.
- Reject title fallback when both sides have conflicting known DOIs.
- Fill only missing external bibliographic fields from the matched Zotero record: DOI, title, authors, year, publication date, source title, and abstract.
- Preserve valid provider metadata instead of overwriting it with local values.
- Record Zotero provenance for fields recovered locally.
- Pass the enriched record downstream so Focus View receives the recovered title/authors directly.

## Tests

Added coverage for:

- DOI-matched local enrichment
- preserving existing provider metadata
- explicit Zotero item-key priority
- conflicting-DOI title matches
- Focus View receiving recovered local title/authors

Note: I could not execute the repository test suite in this environment because outbound GitHub access from the code runner is unavailable; the changes and tests were committed through the GitHub connector.