### PR TITLE
Add DataCite metadata fallback for DOI records

### DIFF
--- a/src/services/dataCiteMetadataService.ts
+++ b/src/services/dataCiteMetadataService.ts
@@ -1,0 +1,238 @@
+import type { RelatedWorkMetadata } from "../domain/citationTypes";
+import { normalizeDOI } from "../domain/workIdentity";
+import { publicationYearOrNull } from "../domain/valueNormalization";
+import type { ProviderRequestOptions } from "../providers/types";
+
+const DATACITE_REQUEST_TIMEOUT_MS = 15000;
+
+interface DataCiteTitle {
+  title?: string;
+  titleType?: string | null;
+}
+
+interface DataCiteNameIdentifier {
+  nameIdentifier?: string;
+  nameIdentifierScheme?: string;
+}
+
+interface DataCiteCreator {
+  name?: string;
+  givenName?: string | null;
+  familyName?: string | null;
+  nameIdentifiers?: DataCiteNameIdentifier[];
+}
+
+interface DataCiteDate {
+  date?: string;
+  dateType?: string;
+}
+
+interface DataCiteAttributes {
+  doi?: string;
+  titles?: DataCiteTitle[];
+  creators?: DataCiteCreator[];
+  publicationYear?: number | string | null;
+  dates?: DataCiteDate[];
+  publisher?: string | { name?: string } | null;
+  container?: { title?: string | null } | null;
+  types?: {
+    resourceType?: string | null;
+    resourceTypeGeneral?: string | null;
+  } | null;
+}
+
+export interface DataCiteResponse {
+  data?: {
+    id?: string;
+    type?: string;
+    attributes?: DataCiteAttributes;
+  } | null;
+}
+
+export interface DataCiteMetadata {
+  doi: string;
+  title: string | null;
+  year: number | null;
+  publicationDate: string | null;
+  authors: string[];
+  authorIDs: string[];
+  sourceTitle: string | null;
+  publicationType: string | null;
+}
+
+function text(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function primaryTitle(titles: DataCiteTitle[] | undefined): string | null {
+  const entries = titles ?? [];
+  const primary = entries.find((entry) => {
+    const type = text(entry.titleType)?.toLocaleLowerCase();
+    return !type || type === "title";
+  });
+  return text(primary?.title ?? entries[0]?.title);
+}
+
+function creatorName(creator: DataCiteCreator): string | null {
+  const direct = text(creator.name);
+  if (direct) return direct;
+  const given = text(creator.givenName);
+  const family = text(creator.familyName);
+  return [given, family].filter(Boolean).join(" ").trim() || null;
+}
+
+function creatorIdentifiers(creator: DataCiteCreator): string[] {
+  return (creator.nameIdentifiers ?? [])
+    .map((identifier) => text(identifier.nameIdentifier))
+    .filter((identifier): identifier is string => Boolean(identifier));
+}
+
+function publicationDate(dates: DataCiteDate[] | undefined): string | null {
+  const entries = dates ?? [];
+  for (const preferredType of ["issued", "published", "available"]) {
+    const matching = entries.find(
+      (entry) => text(entry.dateType)?.toLocaleLowerCase() === preferredType,
+    );
+    const value = text(matching?.date);
+    if (value) return value;
+  }
+  return text(entries[0]?.date);
+}
+
+function publisherName(
+  publisher: DataCiteAttributes["publisher"],
+): string | null {
+  if (typeof publisher === "string") return text(publisher);
+  return text(publisher?.name);
+}
+
+export function dataCiteMetadataFromResponse(
+  response: DataCiteResponse,
+): DataCiteMetadata | null {
+  const attributes = response.data?.attributes;
+  const doi = normalizeDOI(attributes?.doi ?? response.data?.id);
+  if (!attributes || !doi) return null;
+  const authors = (attributes.creators ?? [])
+    .map(creatorName)
+    .filter((author): author is string => Boolean(author));
+  const authorIDs = (attributes.creators ?? []).flatMap(creatorIdentifiers);
+  const year = publicationYearOrNull(attributes.publicationYear);
+  return {
+    doi,
+    title: primaryTitle(attributes.titles),
+    year,
+    publicationDate: publicationDate(attributes.dates),
+    authors,
+    authorIDs: [...new Set(authorIDs)],
+    sourceTitle:
+      text(attributes.container?.title) ?? publisherName(attributes.publisher),
+    publicationType:
+      text(attributes.types?.resourceType) ??
+      text(attributes.types?.resourceTypeGeneral),
+  };
+}
+
+export function needsDataCiteMetadata(work: RelatedWorkMetadata): boolean {
+  return Boolean(
+    normalizeDOI(work.doi) &&
+    (!String(work.title ?? "").trim() ||
+      work.authors.length === 0 ||
+      work.year === null),
+  );
+}
+
+export function mergeDataCiteMetadata<T extends RelatedWorkMetadata>(
+  work: T,
+  metadata: DataCiteMetadata,
+): T {
+  const workDOI = normalizeDOI(work.doi);
+  if (!workDOI || workDOI !== metadata.doi) return work;
+  const currentTitle = String(work.title ?? "").trim();
+  const currentDate = String(work.publicationDate ?? "").trim();
+  const currentSource = String(work.sourceTitle ?? "").trim();
+  const currentType = String(work.publicationType ?? "").trim();
+  return {
+    ...work,
+    title: currentTitle ? work.title : metadata.title,
+    year: work.year ?? metadata.year,
+    publicationDate: currentDate
+      ? work.publicationDate
+      : metadata.publicationDate,
+    authors: work.authors.length ? [...work.authors] : [...metadata.authors],
+    authorIDs: work.authorIDs?.length
+      ? [...work.authorIDs]
+      : [...metadata.authorIDs],
+    sourceTitle: currentSource ? work.sourceTitle : metadata.sourceTitle,
+    publicationType: currentType
+      ? work.publicationType
+      : metadata.publicationType,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+const dataCiteRequests = new Map<string, Promise<DataCiteMetadata | null>>();
+
+export function clearDataCiteMetadataCache(): void {
+  dataCiteRequests.clear();
+}
+
+async function requestDataCiteMetadata(
+  doi: string,
+  options?: ProviderRequestOptions,
+): Promise<DataCiteMetadata | null> {
+  if (options?.signal?.cancelled) return null;
+  let requestCanceller: (() => void) | null = null;
+  const unsubscribe = options?.signal?.subscribe(() => {
+    try {
+      requestCanceller?.();
+    } catch {
+      // The request may already have completed.
+    }
+  });
+  try {
+    const response = await Zotero.HTTP.request(
+      "GET",
+      `https://api.datacite.org/dois/${encodeURIComponent(doi)}`,
+      {
+        headers: {
+          Accept: "application/vnd.api+json",
+          "User-Agent":
+            "Zotero-Citation-Map/0.6 (metadata fallback; public API pool)",
+        },
+        responseType: "text",
+        timeout: DATACITE_REQUEST_TIMEOUT_MS,
+        successCodes: false,
+        cancellerReceiver: (cancel: () => void) => {
+          requestCanceller = cancel;
+          if (options?.signal?.cancelled) cancel();
+        },
+      },
+    );
+    if (options?.signal?.cancelled) return null;
+    if (response.status < 200 || response.status >= 300) return null;
+    const raw = String((response as any).responseText ?? "").trim();
+    if (!raw) return null;
+    return dataCiteMetadataFromResponse(JSON.parse(raw) as DataCiteResponse);
+  } catch (error) {
+    Zotero.debug(
+      `Citation Map: DataCite metadata lookup failed for ${doi}: ${String(error)}`,
+    );
+    return null;
+  } finally {
+    unsubscribe?.();
+  }
+}
+
+export function resolveDataCiteMetadata(
+  doi: string | null | undefined,
+  options?: ProviderRequestOptions,
+): Promise<DataCiteMetadata | null> {
+  const normalized = normalizeDOI(doi);
+  if (!normalized) return Promise.resolve(null);
+  const cached = dataCiteRequests.get(normalized);
+  if (cached) return cached;
+  const request = requestDataCiteMetadata(normalized, options);
+  dataCiteRequests.set(normalized, request);
+  return request;
+}

--- a/src/services/externalWorkMetadataService.ts
+++ b/src/services/externalWorkMetadataService.ts
@@ -150,7 +150,9 @@ export function localExternalWorkIndexes(
   const byDOI = new Map<string, LibraryWorkIdentity>();
   const byTitle = new Map<string, LibraryWorkIdentity>();
   for (const node of nodes) {
-    const key = String(node.itemKey ?? "").trim().toLocaleUpperCase();
+    const key = String(node.itemKey ?? "")
+      .trim()
+      .toLocaleUpperCase();
     const doi = normalizeDOI(node.doi);
     const title = normalizeExactTitle(node.title);
     if (key && !byKey.has(key)) byKey.set(key, node);
@@ -166,9 +168,7 @@ function localWorkForExternal(
   localByTitle: Map<string, LibraryWorkIdentity>,
   localByKey?: Map<string, LibraryWorkIdentity>,
 ): LibraryWorkIdentity | null {
-  const explicitKey = String(
-    work.inLibraryItemKey ?? work.zoteroItemKey ?? "",
-  )
+  const explicitKey = String(work.inLibraryItemKey ?? work.zoteroItemKey ?? "")
     .trim()
     .toLocaleUpperCase();
   if (explicitKey && localByKey) {
@@ -207,7 +207,9 @@ function mergeLocalZoteroMetadata<T extends RelatedWorkMetadata>(
   const localDOI = normalizeDOI(local.doi);
   const workTitle = usableExternalTitle(work.title, workDOI);
   const localTitle = usableExternalTitle(local.title, localDOI);
-  const workAuthors = work.authors.map((author) => author.trim()).filter(Boolean);
+  const workAuthors = work.authors
+    .map((author) => author.trim())
+    .filter(Boolean);
   const localAuthors = (local.authors ?? [])
     .map((author) => String(author ?? "").trim())
     .filter(Boolean);
@@ -239,7 +241,10 @@ function mergeLocalZoteroMetadata<T extends RelatedWorkMetadata>(
     authors: workAuthors.length ? workAuthors : localAuthors,
     year: work.year ?? local.year ?? null,
     publicationDate:
-      workPublicationDate || localPublicationDate || work.publicationDate || null,
+      workPublicationDate ||
+      localPublicationDate ||
+      work.publicationDate ||
+      null,
     sourceTitle: workSourceTitle ?? localSourceTitle,
     abstract: workAbstract ?? localAbstract,
     zoteroItemKey: work.zoteroItemKey ?? local.itemKey,

--- a/src/services/relatedWorkSummaryService.ts
+++ b/src/services/relatedWorkSummaryService.ts
@@ -23,6 +23,11 @@ import {
   stableExternalWorkIdentity,
 } from "../domain/workIdentity";
 import { getOpenAlexAPIKey } from "./citationPreferences";
+import {
+  mergeDataCiteMetadata,
+  needsDataCiteMetadata,
+  resolveDataCiteMetadata,
+} from "./dataCiteMetadataService";
 import { providerExecutionPolicy } from "./providerExecutionPolicy";
 import {
   projectRelatedWorkSummary,
@@ -654,6 +659,22 @@ export async function resolveRelatedWorkSummaries(
       ? Math.max(0, remaining - fallback.used)
       : remaining;
   }
+
+  const dataCiteCandidates = works
+    .map((work, index) => ({ work, index }))
+    .filter(({ work }) => needsDataCiteMetadata(work))
+    .map(({ index }) => index);
+  await mapBounded(
+    dataCiteCandidates,
+    2,
+    async (index) => {
+      const metadata = await resolveDataCiteMetadata(works[index].doi);
+      if (!metadata) return;
+      works[index] = mergeDataCiteMetadata(works[index], metadata);
+      successfullyResolved.add(index);
+    },
+    { yieldAfterEach: true },
+  );
 
   return works.map((work, index) => {
     const identity = stableExternalWorkIdentity(work);

--- a/test/dataCiteMetadataService.test.ts
+++ b/test/dataCiteMetadataService.test.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+import type { RelatedWorkMetadata } from "../src/domain/citationTypes";
+import {
+  dataCiteMetadataFromResponse,
+  mergeDataCiteMetadata,
+  needsDataCiteMetadata,
+} from "../src/services/dataCiteMetadataService";
+
+function work(
+  overrides: Partial<RelatedWorkMetadata> = {},
+): RelatedWorkMetadata {
+  return {
+    provider: "openalex",
+    providerWorkID: "W123",
+    doi: "10.5281/zenodo.8017773",
+    title: null,
+    year: null,
+    authors: [],
+    ...overrides,
+  };
+}
+
+describe("DataCite metadata fallback", function () {
+  it("parses repository DOI metadata into a compact bibliographic summary", function () {
+    const metadata = dataCiteMetadataFromResponse({
+      data: {
+        id: "10.5281/zenodo.8017773",
+        type: "dois",
+        attributes: {
+          doi: "10.5281/zenodo.8017773",
+          titles: [{ title: "Tritium burn fraction analysis code" }],
+          creators: [
+            {
+              name: "Delaporte-Mathurin, Remi",
+              nameIdentifiers: [
+                {
+                  nameIdentifier: "https://orcid.org/0000-0002-1825-0097",
+                  nameIdentifierScheme: "ORCID",
+                },
+              ],
+            },
+          ],
+          publicationYear: 2023,
+          dates: [{ date: "2023-06-08", dateType: "Issued" }],
+          publisher: "Zenodo",
+          container: {},
+          types: {
+            resourceType: "Software",
+            resourceTypeGeneral: "Software",
+          },
+        },
+      },
+    });
+
+    expect(metadata).to.deep.equal({
+      doi: "10.5281/zenodo.8017773",
+      title: "Tritium burn fraction analysis code",
+      year: 2023,
+      publicationDate: "2023-06-08",
+      authors: ["Delaporte-Mathurin, Remi"],
+      authorIDs: ["https://orcid.org/0000-0002-1825-0097"],
+      sourceTitle: "Zenodo",
+      publicationType: "Software",
+    });
+  });
+
+  it("fills only missing bibliographic fields", function () {
+    const metadata = dataCiteMetadataFromResponse({
+      data: {
+        id: "10.5281/zenodo.8017773",
+        attributes: {
+          doi: "10.5281/zenodo.8017773",
+          titles: [{ title: "DataCite title" }],
+          creators: [{ name: "DataCite Author" }],
+          publicationYear: 2023,
+          publisher: "Zenodo",
+          types: { resourceTypeGeneral: "Software" },
+        },
+      },
+    });
+    expect(metadata).not.to.equal(null);
+
+    const merged = mergeDataCiteMetadata(
+      work({
+        title: "Provider title",
+        authors: [],
+        year: null,
+        sourceTitle: null,
+      }),
+      metadata!,
+    );
+
+    expect(merged.title).to.equal("Provider title");
+    expect(merged.authors).to.deep.equal(["DataCite Author"]);
+    expect(merged.year).to.equal(2023);
+    expect(merged.sourceTitle).to.equal("Zenodo");
+    expect(merged.publicationType).to.equal("Software");
+  });
+
+  it("does not merge metadata for a different DOI", function () {
+    const metadata = {
+      doi: "10.5281/zenodo.9999999",
+      title: "Wrong work",
+      year: 2023,
+      publicationDate: null,
+      authors: ["Wrong Author"],
+      authorIDs: [],
+      sourceTitle: "Zenodo",
+      publicationType: "Software",
+    };
+    const original = work();
+    expect(mergeDataCiteMetadata(original, metadata)).to.equal(original);
+  });
+
+  it("requests DataCite only for DOI records missing core identity metadata", function () {
+    expect(needsDataCiteMetadata(work())).to.equal(true);
+    expect(
+      needsDataCiteMetadata(
+        work({ title: "Complete", authors: ["Author"], year: 2023 }),
+      ),
+    ).to.equal(false);
+    expect(needsDataCiteMetadata(work({ doi: null }))).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add a DataCite DOI metadata fallback for external relationship records that remain bibliographically incomplete after the normal provider-resolution chain. This specifically covers repository/software/data DOIs such as Zenodo records that Crossref and the citation providers may not resolve.

### Changes

- Add `dataCiteMetadataService` using the public DataCite REST API for single-DOI metadata lookup.
- Parse title, creators, creator identifiers, publication year/date, repository/container, and resource type.
- Run DataCite only after the normal metadata providers and only for DOI records still missing core identity metadata (title, authors, or year).
- Preserve already-valid provider metadata; DataCite fills only missing bibliographic fields.
- Reject metadata merge if the returned DOI does not match the requested work.
- Bound DataCite hydration to two concurrent requests and session-cache DOI lookups to avoid repeated public-API traffic during redraws.
- Add focused tests for Zenodo-like DataCite responses, non-overwrite behavior, DOI mismatch safety, and fallback eligibility.

## CI / Zotero 10

This branch is based on the merged Zotero 10 update (`v0.6.0`). It also fixes the existing Prettier failure in `externalWorkMetadataService.ts` that was causing `npm run check` on `main` to stop before tests/build.

The DataCite endpoint and response fields follow DataCite's documented single-DOI REST response (`GET /dois/{doi}`).